### PR TITLE
fix 2022 static

### DIFF
--- a/pyconjp.yml
+++ b/pyconjp.yml
@@ -3,6 +3,7 @@
   roles:
     - base
     - { tags: u, role: users }
+    - { tags: w2022, role: web-2022 }
     - { tags: w2021, role: web-2021 }
     - { tags: w2020, role: web-2020 }
     - { tags: w2019, role: web-2019 }

--- a/roles/nginx/files/etc/nginx/sites-enabled/yyyy.pycon.jp.conf
+++ b/roles/nginx/files/etc/nginx/sites-enabled/yyyy.pycon.jp.conf
@@ -1,5 +1,17 @@
 server {
     listen 80;
+    server_name 2022.pycon.jp;
+
+    root /var/www/pyconjp/2022.pycon.jp;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+
+server {
+    listen 80;
     server_name 2021.pycon.jp;
 
     root /var/www/pyconjp/2021.pycon.jp;

--- a/roles/web-2022/tasks/main.yml
+++ b/roles/web-2022/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- set_fact:
+    repository: pyconjp/pycon.jp.2022
+    year: 2022
+
+- git:
+    repo: "https://github.com/{{ repository }}.git"
+    dest: "/var/app/{{ repository }}"
+    version: main
+    depth: 1
+
+- file:
+    state: link
+    src: "/var/app/{{ repository }}/2022"
+    dest: "/var/www/pyconjp/2022.pycon.jp"


### PR DESCRIPTION
PyCon JP 2022のWebサイトのスタティック化対応になります。

PyCon JP 2022のリポジトリ (mainブランチ)
https://github.com/pyconjp/pycon.jp.2022