### PR TITLE
PyConJP 2023 teaserサイトリリースのためのリダイレクト設定を追加

### DIFF
--- a/roles/nginx/files/etc/nginx/sites-enabled/yyyy.pycon.jp.conf
+++ b/roles/nginx/files/etc/nginx/sites-enabled/yyyy.pycon.jp.conf
@@ -1,5 +1,12 @@
 server {
     listen 80;
+    server_name 2023.pycon.jp;
+    return 301 https://pycon-jp-2023-teaser.pages.dev/;
+
+}
+
+server {
+    listen 80;
     server_name 2021.pycon.jp;
 
     root /var/www/pyconjp/2021.pycon.jp;


### PR DESCRIPTION
ここのデプロイ結果を反映。

https://github.com/pyconjp/pycon.jp.2023.teaser
