### PR TITLE
Redirect access to http://pycon.jp on business cards etc. to 2023.pyc…

### DIFF
--- a/roles/nginx/files/etc/nginx/sites-enabled/pycon.jp.conf
+++ b/roles/nginx/files/etc/nginx/sites-enabled/pycon.jp.conf
@@ -14,7 +14,7 @@ server {
     server_name origin.pycon.jp new.pycon.jp pycon.jp;
 
     location = / {
-        return 307 https://2022.pycon.jp;
+        return 307 https://2023.pycon.jp;
     }
 
     location / {


### PR DESCRIPTION
名刺などに記載のhttp://pycon.jpへのアクセスを2023.pycon.jpにリダイレクト