### PR TITLE
Redirect access to http://pycon.jp on business cards etc. to 2024.pycon.jp

### DIFF
--- a/roles/nginx/files/etc/nginx/sites-enabled/pycon.jp.conf
+++ b/roles/nginx/files/etc/nginx/sites-enabled/pycon.jp.conf
@@ -14,7 +14,7 @@ server {
     server_name origin.pycon.jp new.pycon.jp pycon.jp;
 
     location = / {
-        return 307 https://2023-apac.pycon.jp;
+        return 307 https://2024.pycon.jp/;
     }
 
     location / {


### PR DESCRIPTION
名刺などに記載のhttp://pycon.jpのアクセス先を2024サイトに変更

https://pyconjp.atlassian.net/browse/TAT-81
