### PR TITLE
2023のWebサイトがトップページ以外Not Foundになる問題の修正

### DIFF
--- a/roles/nginx/files/etc/nginx/sites-enabled/yyyy.pycon.jp.conf
+++ b/roles/nginx/files/etc/nginx/sites-enabled/yyyy.pycon.jp.conf
@@ -6,7 +6,7 @@ server {
     index index.html;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri.html $uri/ =404;
     }
 }
 
@@ -18,7 +18,7 @@ server {
     index index.html;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri.html $uri/ =404;
     }
 }
 


### PR DESCRIPTION
# 概要
https://2023-apac.pycon.jp/noc などがNot Foundになる問題の修正です

# 修正内容
リクエストされたパスに `.html` を付与したファイルがあるかのチェックを追加しました。